### PR TITLE
fix: turns off gsheets cashing to force loading always new state of gtables

### DIFF
--- a/pages/create_own_table.py
+++ b/pages/create_own_table.py
@@ -119,7 +119,7 @@ st.markdown("""
 def get_usernames() -> list:
     conn = st.connection("gsheets", type=GSheetsConnection)
     try:
-        usernames = conn.read(spreadsheet=url_gtable, usecols=[1])
+        usernames = conn.read(spreadsheet=url_gtable, usecols=[1], ttl=0)
         unique_usernames = pd.unique(usernames[usernames.columns[0]])
         unique_usernames = list(unique_usernames)
     except:
@@ -176,7 +176,7 @@ with st.container(border=True):
 
         conn = st.connection("gsheets", type=GSheetsConnection)
         try:
-            df = conn.read(spreadsheet=url_gtable, usecols=list(range(25)))
+            df = conn.read(spreadsheet=url_gtable, usecols=list(range(25)), ttl=0)
 
             df['Отметка времени'] = pd.to_datetime(df['Отметка времени'], format='%d.%m.%Y %H:%M:%S')
 

--- a/pages/results.py
+++ b/pages/results.py
@@ -23,7 +23,7 @@ def retreive_records(df: pd.DataFrame, key: str, sort_options: dict) -> pd.DataF
 
 conn = st.connection("gsheets", type=GSheetsConnection)
 try:
-    df = conn.read(spreadsheet=url, usecols=[0,1,2,3,4,5,6,7,8,9])
+    df = conn.read(spreadsheet=url, usecols=[0,1,2,3,4,5,6,7,8,9], ttl=0)
     
     df['Отметка времени'] = pd.to_datetime(df['Отметка времени'], format='%d.%m.%Y %H:%M:%S')
     


### PR DESCRIPTION
turns off gsheets cashing to force loading always new state of gtables